### PR TITLE
fix: turn on errors so vignette builds

### DIFF
--- a/vignettes/generate-lockfile.Rmd
+++ b/vignettes/generate-lockfile.Rmd
@@ -46,13 +46,13 @@ axecute(scriptPath, log_name = "log_out_parse", log_path = logDir, show_repo_url
 
 Later on read (and parse) previous log file as list of objects. 
 
-```{r read_logfile, warning = FALSE}
+```{r read_logfile, warning = FALSE, error = TRUE}
 parsedFile <- read_log_file(filePath)
 ```
 
 Create a renv lockfile based on the used packages mentioned in the log file.
 
-```{r gen_lockfile}
+```{r gen_lockfile, error = TRUE}
 pkgs <- parsedFile$`Used Package and Functions` %>%
   transmute(package_name = str_extract(library, "(?<=package\\:).+"))
 


### PR DESCRIPTION
I put error = TRUE in the markdown chunks for the lockfile vignette.

This feels like something with how things are compiled??  As the vignette builds locally for me, but in the packagedown call it falls over.  

Could we output the lock file and store it with how we do the adsl, riskdiff, etc log files??  this way it isn't executing every time we build the website.  not ideal as we will miss stuff but at least it builds?!?!?!
