### PR TITLE
Ensure invisibly returned objects are not printed in log

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,8 @@ Suggests:
     rstudioapi,
     tidyselect,
     renv,
-    yaml
+    yaml,
+    gt
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ## Updates
 
+- Invisibly returned objects are no longer captured in the "Result" section of the log (#275)
+
 - Removed .dcf file for old Addin (#280)
 
 ## Documentation

--- a/R/writer.R
+++ b/R/writer.R
@@ -313,8 +313,10 @@ write_result <- function(file) {
 
   if (is_rmarkdown(file)) {
     c("\nResult:", paste0("\t", capture.output(result)))
-  } else {
+  } else if (isTRUE(result$visible)) {
     c("\nResult:", paste0("\t", capture.output(result$value)))
+  } else {
+    character(0)
   }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,7 +17,7 @@ logrx_default_options <- list(
 
   # This overwrite is to correctly build purrr adverb function
   # outlined in purrr best practices for exporting adverb-wrapped functions
-  run_safely <<- purrr::safely(run_file, quiet = FALSE, visible = TRUE)
+  run_safely <<- purrr::safely(run_file, quiet = FALSE)
 
   # set warn to 1 to have warnings be output as they happen
   options(warn = 1)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -17,7 +17,7 @@ logrx_default_options <- list(
 
   # This overwrite is to correctly build purrr adverb function
   # outlined in purrr best practices for exporting adverb-wrapped functions
-  run_safely <<- purrr::safely(run_file, quiet = FALSE)
+  run_safely <<- purrr::safely(run_file, quiet = FALSE, visible = TRUE)
 
   # set warn to 1 to have warnings be output as they happen
   options(warn = 1)

--- a/tests/testthat/ref/invisible_returned_gt.R
+++ b/tests/testthat/ref/invisible_returned_gt.R
@@ -1,0 +1,4 @@
+library(gt)
+
+gt_tbl <- gt(head(mtcars))
+gt_tbl

--- a/tests/testthat/ref/invisible_returned_gt.R
+++ b/tests/testthat/ref/invisible_returned_gt.R
@@ -1,4 +1,4 @@
 library(gt)
 
-gt_tbl <- gt(head(mtcars))
+gt_tbl <- gt::gt(head(mtcars))
 gt_tbl

--- a/tests/testthat/ref/invisible_returned_obj.R
+++ b/tests/testthat/ref/invisible_returned_obj.R
@@ -1,0 +1,4 @@
+my_fun <- function(x){
+  return(invisible(x))
+}
+my_fun("do not print this")

--- a/tests/testthat/ref/invisible_returned_obj.R
+++ b/tests/testthat/ref/invisible_returned_obj.R
@@ -1,4 +1,4 @@
-my_fun <- function(x){
+my_fun <- function(x) {
   return(invisible(x))
 }
 my_fun("do not print this")

--- a/tests/testthat/ref/invisible_returned_obj.Rmd
+++ b/tests/testthat/ref/invisible_returned_obj.Rmd
@@ -1,0 +1,11 @@
+---
+title: "invisible_returned_obj"
+output: html_document
+---
+
+```{r}
+my_fun <- function(x){
+  return(invisible(x))
+}
+my_fun("do not print this")
+```

--- a/tests/testthat/ref/invisible_returned_obj.Rmd
+++ b/tests/testthat/ref/invisible_returned_obj.Rmd
@@ -4,7 +4,7 @@ output: html_document
 ---
 
 ```{r}
-my_fun <- function(x){
+my_fun <- function(x) {
   return(invisible(x))
 }
 my_fun("do not print this")

--- a/tests/testthat/test-invisible.R
+++ b/tests/testthat/test-invisible.R
@@ -48,3 +48,20 @@ test_that("visibly returned results are written to the log", {
   rm(flines, con, logDir)
   log_remove()
 })
+
+test_that("gt table HTML content is not written to the result portion of the log", {
+  options("log.rx" = NULL)
+  scriptPath <- test_path("ref", "invisible_returned_gt.R")
+  logDir <- tempdir()
+
+  axecute(scriptPath, log_name = "log_gt", log_path = logDir)
+
+  con <- file(file.path(logDir, "log_gt"), "r")
+  flines <- readLines(con)
+  close(con)
+
+  expect_false(any(grepl("<table", flines, fixed = TRUE)))
+
+  rm(flines, con, logDir)
+  log_remove()
+})

--- a/tests/testthat/test-invisible.R
+++ b/tests/testthat/test-invisible.R
@@ -15,6 +15,23 @@ test_that("invisibly returned results are not written to the log", {
   log_remove()
 })
 
+test_that("invisibly returned results in Rmd files are not written to the log", {
+  options("log.rx" = NULL)
+  scriptPath <- test_path("ref", "invisible_returned_obj.Rmd")
+  logDir <- tempdir()
+
+  axecute(scriptPath, log_name = "log_invisible_rmd", log_path = logDir)
+
+  con <- file(file.path(logDir, "log_invisible_rmd"), "r")
+  flines <- readLines(con)
+  close(con)
+
+  expect_false(any(grepl("do not print this", flines)))
+
+  rm(flines, con, logDir)
+  log_remove()
+})
+
 test_that("visibly returned results are written to the log", {
   options("log.rx" = NULL)
   scriptPath <- test_path("ref", "safely_loudly_test_file_result.R")

--- a/tests/testthat/test-invisible.R
+++ b/tests/testthat/test-invisible.R
@@ -1,0 +1,33 @@
+test_that("invisibly returned results are not written to the log", {
+  options("log.rx" = NULL)
+  scriptPath <- test_path("ref", "invisible_returned_obj.R")
+  logDir <- tempdir()
+
+  axecute(scriptPath, log_name = "log_invisible", log_path = logDir)
+
+  con <- file(file.path(logDir, "log_invisible"), "r")
+  flines <- readLines(con)
+  close(con)
+
+  expect_false(any(grepl("do not print this", flines)))
+
+  rm(flines, con, logDir)
+  log_remove()
+})
+
+test_that("visibly returned results are written to the log", {
+  options("log.rx" = NULL)
+  scriptPath <- test_path("ref", "safely_loudly_test_file_result.R")
+  logDir <- tempdir()
+
+  axecute(scriptPath, log_name = "log_visible", log_path = logDir)
+
+  con <- file(file.path(logDir, "log_visible"), "r")
+  flines <- readLines(con)
+  close(con)
+
+  expect_true(any(grepl("8, 6, 7, 5, 3, 0, 9|test", flines)))
+
+  rm(flines, con, logDir)
+  log_remove()
+})


### PR DESCRIPTION
Associated with #275.

### Thank you for your Pull Request! 

We have developed a Pull Request template to aid you and our reviewers.  Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the logrx codebase remains robust and consistent.  

### The spirit of logrx

While many packages to facilitate the logging of code already exist in the R ecosystem, it is hard to find a solution that works well for clinical programming applications. Many logging implementations are more implicit and rely on user input to create the log for the execution of a script. While this is useful for logging specific events of an application, in clinical programming a log has a set purpose.

logrx is built around the concept of creating a log for the execution of an R script that provides an overview of what happened as well as the environment that it happened in. We set out to create a flexible logging utility that could provide the necessary information to anyone reviewing the code execution so they can recreate the execution environment and run the code for themselves. Please make sure your Pull Request meets this **spirit of logrx**.

Please check off each taskbox as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `dev` branch until you have checked off each task.

- [x] The spirit of logrx is met in your Pull Request
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/) 
- [x] Updated relevant unit tests or have written new unit tests.  Remember to remove any configured log objects at the end of every test using `log_remove()`.
- [x] Creation/updates to relevant roxygen headers and examples.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue so that it closes after successful merging. 
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!
