### PR TITLE
fix: attribute replacement functions to correct package (#271)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,7 +68,8 @@ Suggests:
     rstudioapi,
     tidyselect,
     renv,
-    yaml
+    yaml,
+    common
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Depends: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -68,8 +68,7 @@ Suggests:
     rstudioapi,
     tidyselect,
     renv,
-    yaml,
-    common
+    yaml
 VignetteBuilder: knitr
 Config/testthat/edition: 3
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ## New Features
 
+## Bug Fixes
+
+- Fixed package detection failure for backtick-quoted and replacement functions in `get_used_functions()` (#271)
+
 ## Updates
 
 - Removed .dcf file for old Addin (#280)

--- a/R/get.R
+++ b/R/get.R
@@ -275,7 +275,9 @@ get_library <- function(df) {
     if (pkg_name != .x && isNamespaceLoaded(pkg_name)) {
       getNamespaceExports(pkg_name)
     } else {
-      character(0)
+      # For non-package environments attached to the search path (e.g. in tests),
+      # fall back to ls() so replacement functions like labels<- are visible.
+      tryCatch(ls(as.environment(.x)), error = function(e) character(0))
     }
   }
 
@@ -309,6 +311,8 @@ get_library <- function(df) {
 
 
 get_first <- function(func, search_lookup, namespace_lookup, is_replacement = FALSE) {
+  # strip backticks so explicit calls like `colnames<-`(x, y) match exported names
+  func <- gsub("`", "", func)
   flag_found <- map(search_lookup, ~ func %in% .)
   found_any <- any(unlist(flag_found))
 
@@ -328,7 +332,9 @@ get_first <- function(func, search_lookup, namespace_lookup, is_replacement = FA
     }
   }
 
-  if (!found_any) return(NA)
+  if (!found_any) {
+    return(NA)
+  }
   names(flag_found[flag_found == TRUE][1])
 }
 

--- a/R/get.R
+++ b/R/get.R
@@ -182,8 +182,29 @@ get_used_functions <- function(file) {
     )
   }
 
-  tokens <- getParseData(ret$result) %>%
-    filter(.data[["token"]] %in% c("SYMBOL_FUNCTION_CALL", "SPECIAL", "SYMBOL_PACKAGE"))
+  tokens <- getParseData(ret$result)
+
+  # Identify SYMBOL_FUNCTION_CALL tokens used as replacement functions
+  # (e.g. labels(df) <- ...). In the parse tree, LEFT_ASSIGN and its LHS/RHS
+  # exprs are siblings under the same parent. For a replacement call, the LHS
+  # expr (id < LEFT_ASSIGN id, same parent) contains a SYMBOL_FUNCTION_CALL.
+  # For plain assignment (df <- data.frame(...)), the LHS contains a SYMBOL.
+  # We restrict to the LHS expr only to avoid tagging RHS function calls.
+  left_assign_rows <- tokens[tokens$token == "LEFT_ASSIGN", c("id", "parent")]
+  lhs_expr_ids <- unlist(lapply(seq_len(nrow(left_assign_rows)), function(i) {
+    la_id <- left_assign_rows$id[i]
+    la_parent <- left_assign_rows$parent[i]
+    tokens$id[tokens$parent == la_parent & tokens$token == "expr" & tokens$id < la_id]
+  }))
+  lhs_inner_expr <- tokens$id[tokens$parent %in% lhs_expr_ids & tokens$token == "expr"]
+  replacement_ids <- tokens$id[
+    tokens$parent %in% lhs_inner_expr &
+      tokens$token == "SYMBOL_FUNCTION_CALL"
+  ]
+
+  tokens <- tokens %>%
+    filter(.data[["token"]] %in% c("SYMBOL_FUNCTION_CALL", "SPECIAL", "SYMBOL_PACKAGE")) %>%
+    mutate(is_replacement = .data[["id"]] %in% replacement_ids)
 
   if (nrow(tokens) == 0) {
     return(NULL)
@@ -196,11 +217,11 @@ get_used_functions <- function(file) {
       .data[["token"]],
       c("SYMBOL_FUNCTION_CALL", "SPECIAL", "SYMBOL_PACKAGE")
     )) %>%
-    group_by(.data[["line1"]], .data[["parent"]]) %>%
+    group_by(.data[["line1"]], .data[["parent"]], .data[["is_replacement"]]) %>%
     complete(token = .data[["token"]])
 
   wide_tokens <- pivot_wider(filtered_tokens,
-    id_cols = all_of(c("line1", "parent")),
+    id_cols = all_of(c("line1", "parent", "is_replacement")),
     values_from = "text",
     names_from = "token"
   ) %>%
@@ -237,7 +258,7 @@ get_used_functions <- function(file) {
 #' @param df dataframe containing variables `function_name` and `SYMBOL_PACKAGE`
 #' @importFrom dplyr mutate
 #' @importFrom rlang .data
-#' @importFrom purrr map
+#' @importFrom purrr map map2
 #' @importFrom utils lsf.str
 #'
 #' @return tibble that includes `library`
@@ -247,6 +268,15 @@ get_used_functions <- function(file) {
 get_library <- function(df) {
   functions_only <- function(.x) {
     intersect(ls(.x), lsf.str(.x))
+  }
+
+  pkg_namespace_exports <- function(.x) {
+    pkg_name <- sub("^package:", "", .x)
+    if (pkg_name != .x && isNamespaceLoaded(pkg_name)) {
+      getNamespaceExports(pkg_name)
+    } else {
+      character(0)
+    }
   }
 
   # do not search CheckExEnv, this is created while examples are executed
@@ -259,7 +289,15 @@ get_library <- function(df) {
 
   search_lookup <- map(search_environ, functions_only)
   names(search_lookup) <- search_environ
-  df$library <- unlist(map(df$function_name, ~ get_first(., search_lookup)))
+
+  namespace_lookup <- map(search_environ, pkg_namespace_exports)
+  names(namespace_lookup) <- search_environ
+
+  df$library <- unlist(map2(
+    df$function_name,
+    if ("is_replacement" %in% names(df)) df$is_replacement else rep(FALSE, nrow(df)),
+    ~ get_first(.x, search_lookup, namespace_lookup, .y)
+  ))
 
   df %>%
     mutate(library = ifelse(
@@ -270,13 +308,28 @@ get_library <- function(df) {
 }
 
 
-get_first <- function(func, search_lookup) {
+get_first <- function(func, search_lookup, namespace_lookup, is_replacement = FALSE) {
   flag_found <- map(search_lookup, ~ func %in% .)
-  if (any(unlist(flag_found))) {
-    names(flag_found[flag_found == TRUE][1])
-  } else {
-    NA
+  found_any <- any(unlist(flag_found))
+
+  # Only check for a replacement form (func<-) when the token was parsed as a
+  # replacement call (i.e. labels(df) <- ...). Plain calls like labels(df)
+  # should resolve via the normal search path without replacement preference.
+  if (is_replacement) {
+    flag_found_replacement <- map(namespace_lookup, ~ paste0(func, "<-") %in% .)
+    found_any_replacement <- any(unlist(flag_found_replacement))
+
+    if (found_any_replacement) {
+      first_replacement <- which(unlist(flag_found_replacement))[1]
+      first_plain <- if (found_any) which(unlist(flag_found))[1] else Inf
+      if (first_replacement <= first_plain) {
+        return(names(flag_found_replacement[flag_found_replacement == TRUE][1]))
+      }
+    }
   }
+
+  if (!found_any) return(NA)
+  names(flag_found[flag_found == TRUE][1])
 }
 
 #' Get unapproved packages and functions used

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -44,3 +44,4 @@ tibble
 tidylog
 tidyr
 unintrusive
+backtick

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -254,6 +254,43 @@ test_that("functions used are returned correctly for rmd files", {
   expect_identical(get_used_functions(tmpfile), expected)
 })
 
+test_that("replacement functions are attributed to the correct package", {
+  skip_if_not_installed("common")
+
+  # common must be loaded before calling get_used_functions because the function
+  # resolves package attribution by searching the current search path. In normal
+  # usage, axecute() runs the script first (which calls library(common)), and
+  # then calls get_used_functions() against the populated search path. We
+  # replicate that here by loading common explicitly before the call.
+  library(common)
+  withr::defer(detach("package:common", unload = TRUE))
+
+  r_path <- tempfile(fileext = ".R")
+  withr::defer(unlink(r_path))
+
+  writeLines(
+    c(
+      "library(common)",
+      "df <- data.frame(a = 1, b = 2)",
+      # labels() exists in both base and common. common exports labels<- as a
+      # replacement function. The parser captures the token as "labels" (the <-
+      # is a separate token), so without checking the namespace for replacement
+      # forms, the attribution would incorrectly resolve to base.
+      "labels(df) <- list(a = 'A1', b = 'B1')",
+      # A plain call to labels() (no assignment) should still resolve to base.
+      "labels(df)"
+    ),
+    con = r_path
+  )
+
+  result <- get_used_functions(r_path)
+
+  labels_result <- result[result$function_name == "labels", ]$library
+
+  expect_equal(labels_result[1], "package:common")
+  expect_equal(labels_result[2], "package:base")
+})
+
 test_that("get_repo_urls returns correct list of repos", {
   original_repos <- options("repos")
   test_repos <- c(

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -260,7 +260,10 @@ test_that("replacement functions are attributed to the correct package", {
   # function that also exists in base (e.g. common::labels<-). This avoids
   # declaring common as a dependency while still testing the disambiguation.
   e <- new.env(parent = emptyenv())
-  assign("labels<-", function(x, value) { attr(x, "labels") <- value; x }, envir = e)
+  assign("labels<-", function(x, value) {
+    attr(x, "labels") <- value
+    x
+  }, envir = e)
   attach(e, name = "package:fakelabels", warn.conflicts = FALSE)
   withr::defer(detach("package:fakelabels"))
 

--- a/tests/testthat/test-get.R
+++ b/tests/testthat/test-get.R
@@ -255,27 +255,26 @@ test_that("functions used are returned correctly for rmd files", {
 })
 
 test_that("replacement functions are attributed to the correct package", {
-  skip_if_not_installed("common")
-
-  # common must be loaded before calling get_used_functions because the function
-  # resolves package attribution by searching the current search path. In normal
-  # usage, axecute() runs the script first (which calls library(common)), and
-  # then calls get_used_functions() against the populated search path. We
-  # replicate that here by loading common explicitly before the call.
-  library(common)
-  withr::defer(detach("package:common", unload = TRUE))
+  # Attach a local environment to the search path that exports labels<-,
+  # replicating the scenario where a package provides a replacement form of a
+  # function that also exists in base (e.g. common::labels<-). This avoids
+  # declaring common as a dependency while still testing the disambiguation.
+  e <- new.env(parent = emptyenv())
+  assign("labels<-", function(x, value) { attr(x, "labels") <- value; x }, envir = e)
+  attach(e, name = "package:fakelabels", warn.conflicts = FALSE)
+  withr::defer(detach("package:fakelabels"))
 
   r_path <- tempfile(fileext = ".R")
   withr::defer(unlink(r_path))
 
   writeLines(
     c(
-      "library(common)",
+      "library(fakelabels)",
       "df <- data.frame(a = 1, b = 2)",
-      # labels() exists in both base and common. common exports labels<- as a
-      # replacement function. The parser captures the token as "labels" (the <-
-      # is a separate token), so without checking the namespace for replacement
-      # forms, the attribution would incorrectly resolve to base.
+      # labels<- exists in fakelabels (on search path). The parser captures the
+      # token as "labels" (the <- is a separate token), so without checking the
+      # namespace for replacement forms, attribution would incorrectly resolve
+      # to base.
       "labels(df) <- list(a = 'A1', b = 'B1')",
       # A plain call to labels() (no assignment) should still resolve to base.
       "labels(df)"
@@ -287,7 +286,7 @@ test_that("replacement functions are attributed to the correct package", {
 
   labels_result <- result[result$function_name == "labels", ]$library
 
-  expect_equal(labels_result[1], "package:common")
+  expect_equal(labels_result[1], "package:fakelabels")
   expect_equal(labels_result[2], "package:base")
 })
 


### PR DESCRIPTION
### Thank you for your Pull Request! 

We have developed a Pull Request template to aid you and our reviewers.  Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the logrx codebase remains robust and consistent.  

### The spirit of logrx

While many packages to facilitate the logging of code already exist in the R ecosystem, it is hard to find a solution that works well for clinical programming applications. Many logging implementations are more implicit and rely on user input to create the log for the execution of a script. While this is useful for logging specific events of an application, in clinical programming a log has a set purpose.

logrx is built around the concept of creating a log for the execution of an R script that provides an overview of what happened as well as the environment that it happened in. We set out to create a flexible logging utility that could provide the necessary information to anyone reviewing the code execution so they can recreate the execution environment and run the code for themselves. Please make sure your Pull Request meets this **spirit of logrx**.

Please check off each taskbox as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `dev` branch until you have checked off each task.

- [x] The spirit of logrx is met in your Pull Request
- [x] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/) 
- [x] Updated relevant unit tests or have written new unit tests.  Remember to remove any configured log objects at the end of every test using `log_remove()`.
- [x] Creation/updates to relevant roxygen headers and examples.
- [x] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [x] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new functions occur on the "Reference" page.
- [x] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [x] Address any updates needed for vignettes and/or templates
- [x] Run `R CMD check` locally and address all errors and warnings - `devtools::check()`
- [x] Link the issue so that it closes after successful merging. 
- [x] Address all merge conflicts and resolve appropriately 
- [x] Pat yourself on the back for a job well done!  Much love to your accomplishment!
